### PR TITLE
fix: Fix deprecated warning for IAM for EKS SA

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/main.tf
+++ b/modules/iam-role-for-service-accounts-eks/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id          = data.aws_caller_identity.current.account_id
   partition           = data.aws_partition.current.partition
   dns_suffix          = data.aws_partition.current.dns_suffix
-  region              = data.aws_region.current.name
+  region              = data.aws_region.current.region
   role_name_condition = var.role_name != null ? var.role_name : "${var.role_name_prefix}*"
 }
 


### PR DESCRIPTION
fix: Replace `data.aws_region.current.name` with `data.aws_region.current.region` as per https://github.com/terraform-aws-modules/terraform-aws-iam/issues/574